### PR TITLE
Readiness foundation: OSS baseline, docs, CI hardening, and contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,43 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-  lint-and-test:
+  quality:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
 
-    - name: Install dependencies
-      run: uv sync --extra dev --extra test
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Lint with ruff
-      run: uv run ruff check .
+      - name: Install dependencies
+        run: uv sync --extra dev --extra test
 
-    - name: Test with pytest
-      run: uv run pytest --cov=noteshift --cov-report=term tests/
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Ruff lint
+        run: uv run ruff check .
+
+      - name: Type check (baseline)
+        run: uv run mypy src
+        continue-on-error: true
+
+      - name: Unit and integration tests
+        run: uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=55 tests/
+
+      - name: Contract tests (vcr replay)
+        run: uv run pytest -m contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project aims to follow Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+- OSS baseline docs (`LICENSE`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`)
+- Initial pytest-vcr contract harness scaffolding
+- Customer pain map and release checklist docs
+
+### Changed
+- Refreshed README to reflect current CLI behavior and env vars
+- Hardened CI to include formatting and mypy checks

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of positive behavior include:
+
+- being respectful and constructive
+- accepting feedback gracefully
+- focusing on what is best for the community and users
+
+Examples of unacceptable behavior include harassment, abuse, and personal attacks.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing our standards.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to noteshift
+
+## Setup
+
+```bash
+uv sync --extra dev --extra test
+```
+
+## Quality bar
+
+Before opening a PR:
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+uv run pytest --cov=noteshift --cov-report=term
+```
+
+## Pull requests
+
+- Keep PRs focused and small.
+- Reference linked issue(s).
+- Include tests for behavior changes.
+- Update docs for any CLI/API changes.
+
+## Contract tests
+
+`pytest-vcr` cassettes must be sanitized. Never commit live tokens or private identifiers.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fragment256
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,95 +1,99 @@
 # noteshift
 
-![PyPI](https://img.shields.io/pypi/v/noteshift)
-![Python](https://img.shields.io/pypi/pyversions/noteshift)
-![Tests](https://github.com/lukemaxwell/noteshift/actions/workflows/ci.yml/badge.svg)
+`noteshift` exports Notion content to Obsidian-friendly Markdown with predictable filenames, link rewriting, and checkpoint/resume support.
 
-`Notion exporter for seamless Obsidian migration.`
+![CI](https://github.com/Fragment256/noteshift/actions/workflows/ci.yml/badge.svg)
 
-## 🚀 What is noteshift?
+## Why it exists
 
-`noteshift` is a powerful command-line tool designed to facilitate the migration of your notes from Notion to Obsidian. It aims to provide a robust and efficient way to export your Notion pages and databases, preserving your data structure and content as closely as possible.
+Teams migrating from Notion to Obsidian consistently report four pains:
 
-## ✨ MVP Features
+1. broken internal links after export
+2. inconsistent filenames and folder layout
+3. long exports failing midway without resume
+4. low confidence in migration correctness
 
-*   **Page Export**: Export individual Notion pages and their content.
-*   **Database Export**: Export Notion databases into a structured format suitable for Obsidian.
-*   **Link Rewriting**: Automatically rewrites Notion internal links to Obsidian-compatible links.
-*   **Attachments**: Handles image and file attachments, ensuring they are correctly exported and linked.
-*   **Checkpoint/Resume**: Supports resuming interrupted migrations, saving progress and preventing data loss.
-*   **Migration Reports**: Generates detailed reports on the migration process, highlighting successes and any encountered issues.
+`noteshift` is focused on solving those pains first.
 
-## 📦 Installation
+## Current capabilities
 
-You can install `noteshift` using `pip` or `uv` directly from its Git repository:
+- Export a Notion page tree to Markdown
+- Export Notion data sources/databases through API layer
+- Rewrite internal links for Obsidian compatibility
+- Preserve and download attachments
+- Resume interrupted runs via checkpoint file
+- Emit migration report (`migration_report.json` + `.md`)
 
-```bash
-# Using pip
-pip install git+https://github.com/yourusername/noteshift.git
-
-# Using uv
-# uv install git+https://github.com/yourusername/noteshift.git
-```
-
-*(Note: Replace `https://github.com/yourusername/noteshift.git` with the actual repository URL if different.)*
-
-## 🔌 Environment Variables
-
-`noteshift` requires your Notion API integration token to authenticate with the Notion API.
-
-*   `NOTESHIFT_NOTION_TOKEN`: Your Notion Internal Integration Token.
-
-Ensure this token is set in your environment before running the tool.
-
-## 🎮 Basic Usage
-
-Here's a simple example of how to use `noteshift` from your terminal:
+## Installation
 
 ```bash
-export NOTESHIFT_NOTION_TOKEN="your_super_secret_token"
-noteshift export --space-id "your_notion_space_id" --output-dir ./my-notion-export
+uv tool install .
+# or for development
+uv sync --extra dev --extra test
 ```
 
-This command will export your Notion content from the specified space ID to the `./my-notion-export` directory.
+## Authentication
 
-## 📁 Output Structure
+Set a Notion integration token in `NOTION_TOKEN`.
 
-Upon a successful export, `noteshift` will create a directory structure that mirrors your Notion hierarchy, with Markdown files (`.md`) for pages and associated assets (like images) placed alongside them. Database exports will be in a structured format (e.g., CSV or JSON) within the output directory.
-
-## 🛠️ Development Setup
-
-To set up `noteshift` for development, follow these steps:
-
-1.  **Clone the repository**:
-    ```bash
-    git clone https://github.com/yourusername/noteshift.git
-    cd noteshift
-    ```
-
-2.  **Create and activate a virtual environment**:
-    ```bash
-    python -m venv .venv
-    source .venv/bin/activate
-    # or for uv:
-    # uv venv
-    # source .venv/bin/activate
-    ```
-
-3.  **Install dependencies**:
-    ```bash
-    # Using pip
-pip install -e .[dev]
-
-# Using uv
-# uv sync --dev
+```bash
+export NOTION_TOKEN="secret_xxx"
 ```
 
-*(Note: `.[dev]` or `--dev` assumes your `pyproject.toml` defines a `[project.optional-dependencies]` for development tools like linters, formatters, etc.)*
+## Basic usage
 
-4.  **Run linters/formatters (optional but recommended)**:
-    ```bash
-    ruff check .
-    ruff format .
-    ```
+```bash
+noteshift export \
+  --page-id "<notion-page-id>" \
+  --out ./export \
+  --max-depth 2 \
+  --overwrite
+```
 
-Now you are ready to make changes and contribute!
+## Output
+
+A successful run writes:
+
+- Markdown files for exported pages
+- downloaded assets in the export tree
+- `.checkpoint.json` for resume
+- `migration_report.json`
+- `migration_report.md`
+
+## Development
+
+```bash
+uv sync --extra dev --extra test
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+uv run pytest --cov=noteshift --cov-report=term
+```
+
+## Contract tests (`pytest-vcr`)
+
+Contract tests are deterministic and replay HTTP traffic from sanitized cassettes:
+
+```bash
+uv run pytest -m contract
+```
+
+To re-record cassettes intentionally, set a real token in your environment and run:
+
+```bash
+VCR_RECORD_MODE=once uv run pytest -m contract
+```
+
+## Roadmap and readiness
+
+Readiness work is tracked in GitHub issues:
+
+- Epic: transfer + production/open-source readiness
+- OSS baseline docs and metadata
+- CI hardening
+- customer-pain validation matrix
+- contract/e2e test expansion
+
+## License
+
+MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Report privately to the maintainers with:
+
+- affected version/commit
+- impact summary
+- reproduction steps
+- suggested mitigation (if known)
+
+## Secrets and test artifacts
+
+- Never commit Notion tokens.
+- `pytest-vcr` cassettes must be sanitized.
+- Pull requests containing secrets will be rejected.

--- a/docs/spec/customer_pain_map.md
+++ b/docs/spec/customer_pain_map.md
@@ -1,0 +1,41 @@
+# Customer Pain Map
+
+## Scope
+This document maps concrete migration pain to implemented capabilities, tests, and acceptance criteria.
+
+## Pain 1: Internal links break after migration
+- Capability: internal Notion link rewriting to Obsidian-friendly links
+- Acceptance criteria:
+  - links between exported pages resolve to generated markdown targets
+  - no raw Notion URL remains where resolvable target exists
+- Validation:
+  - unit tests in markdown/link rewrite paths
+  - export integration snapshot checks (#11)
+
+## Pain 2: Output naming/layout is inconsistent
+- Capability: deterministic filename normalization and stable folder layout
+- Acceptance criteria:
+  - repeated exports of same content generate identical paths
+  - illegal filename characters are normalized
+- Validation:
+  - unit tests for filename normalization
+  - integration snapshot checks (#11)
+
+## Pain 3: Long migrations fail midway with no resume
+- Capability: checkpoint save/load and resume behavior
+- Acceptance criteria:
+  - interrupted run can continue without re-exporting completed items
+  - force mode intentionally resets checkpoint behavior
+- Validation:
+  - checkpoint unit tests
+  - integration/e2e interruption simulation (#11)
+
+## Pain 4: Teams cannot trust migration correctness
+- Capability: migration report + deterministic tests (unit, contract, integration)
+- Acceptance criteria:
+  - each export emits summary metrics and warnings/errors
+  - CI fails on regressions
+- Validation:
+  - unit tests
+  - pytest-vcr contract tests (#10)
+  - integration/e2e smoke tests (#11)

--- a/docs/spec/fragment256_transfer_plan.md
+++ b/docs/spec/fragment256_transfer_plan.md
@@ -1,0 +1,19 @@
+# Fragment256 Transfer Plan
+
+## Goal
+Move canonical repository ownership from `lukemaxwell/noteshift` to `Fragment256/noteshift` with no workflow downtime.
+
+## Steps
+1. Transfer repository ownership in GitHub settings (preferred over re-create).
+2. Re-confirm admin/write permissions for maintainers and teams.
+3. Validate branch protections on `main`.
+4. Verify GitHub Actions secrets and environment protections.
+5. Update badges/URLs/package metadata to Fragment256 URLs.
+6. Update local remotes:
+   - `git remote set-url origin git@github.com:Fragment256/noteshift.git`
+7. Run CI on a no-op PR to confirm post-transfer health.
+
+## Verification
+- All workflows green after transfer.
+- Existing open issues/PRs retained.
+- README, metadata, and release links point to Fragment256 only.

--- a/docs/spec/release_checklist.md
+++ b/docs/spec/release_checklist.md
@@ -1,0 +1,21 @@
+# Release Checklist
+
+## Pre-release
+- [ ] `uv sync --extra dev --extra test`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run ruff check .`
+- [ ] `uv run mypy src`
+- [ ] `uv run pytest --cov=noteshift --cov-report=term`
+- [ ] Contract tests pass (`uv run pytest -m contract`)
+- [ ] README examples verified
+- [ ] CHANGELOG updated
+
+## Tag and release
+- [ ] bump version in `pyproject.toml`
+- [ ] create git tag `vX.Y.Z`
+- [ ] push tag and verify release workflow
+- [ ] publish release notes
+
+## Post-release
+- [ ] smoke test install from released artifact
+- [ ] verify docs and badges reference latest release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,52 @@
 [project]
 name = "noteshift"
 version = "0.1.0"
-description = "Add your description here"
+description = "Export Notion pages and databases to Obsidian-friendly Markdown."
 readme = "README.md"
-authors = [
-    { name = "Luke", email = "lukemaxwellshouse@gmail.com" }
-]
 requires-python = ">=3.12"
-dependencies = [
-    "httpx>=0.28.1",
-    "python-slugify>=8.0.4",
-    "typer>=0.24.1",
+license = { text = "MIT" }
+authors = [
+    { name = "Fragment256" }
 ]
+keywords = ["notion", "obsidian", "migration", "markdown", "export"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "httpx>=0.28.1,<0.29",
+    "python-slugify>=8.0.4,<9",
+    "typer>=0.24.1,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/Fragment256/noteshift"
+Repository = "https://github.com/Fragment256/noteshift"
+Issues = "https://github.com/Fragment256/noteshift/issues"
 
 [project.scripts]
 noteshift = "noteshift.cli:main"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=9.0.2",
-    "pytest-cov>=6.0.0",
-    "ruff>=0.15.4",
+    "mypy>=1.18.1,<2",
+    "pytest>=9.0.2,<10",
+    "pytest-cov>=6.0.0,<7",
+    "pytest-vcr>=1.0.2,<2",
+    "ruff>=0.15.4,<0.16",
 ]
 test = [
-    "pytest>=9.0.2",
-    "pytest-cov>=6.0.0"
+    "pytest>=9.0.2,<10",
+    "pytest-cov>=6.0.0,<7",
+    "pytest-vcr>=1.0.2,<2",
 ]
 
 [tool.ruff]
-line-length = 110
+line-length = 88
 target-version = "py312"
 
 [tool.ruff.lint]
@@ -37,6 +55,21 @@ ignore = ["B008"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+addopts = "-q"
+testpaths = ["tests"]
+markers = [
+    "contract: deterministic API contract tests (vcr-backed)",
+]
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+check_untyped_defs = true
+no_implicit_optional = true
+strict_equality = true
+mypy_path = "src"
 
 [build-system]
 requires = ["uv_build>=0.10.4,<0.11.0"]

--- a/src/noteshift/api.py
+++ b/src/noteshift/api.py
@@ -18,7 +18,9 @@ def _emit(progress: ProgressSink | None, event: ProgressEvent) -> None:
         progress(event)
 
 
-def _write_migration_report(out_dir: Path, checkpoint: Checkpoint) -> tuple[Path, list[str]]:
+def _write_migration_report(
+    out_dir: Path, checkpoint: Checkpoint
+) -> tuple[Path, list[str]]:
     report_errors: list[str] = []
     report_data = {
         "timestamp": datetime.now(UTC).isoformat(),
@@ -47,7 +49,10 @@ def _write_migration_report(out_dir: Path, checkpoint: Checkpoint) -> tuple[Path
             f"| Pages Exported | {report_data['pages_exported_total']} |",
             f"| Databases Exported | {report_data['databases_exported_total']} |",
             f"| Rows Exported | {report_data['rows_exported_total']} |",
-            f"| Attachments Downloaded | {report_data['attachments_downloaded_total']} |",
+            (
+                "| Attachments Downloaded | "
+                f"{report_data['attachments_downloaded_total']} |"
+            ),
             f"| Files Written | {report_data['files_written_total']} |",
             "",
             "## Warnings",
@@ -87,7 +92,9 @@ def preflight(plan: ExportPlan, config: NoteshiftConfig) -> PreflightReport:
         )
 
     if not plan.page_ids and not plan.database_ids:
-        errors.append("Export plan is empty. Provide at least one page_id or database_id.")
+        errors.append(
+            "Export plan is empty. Provide at least one page_id or database_id."
+        )
 
     if config.max_depth < 0:
         errors.append("max_depth must be >= 0.")
@@ -100,7 +107,10 @@ def preflight(plan: ExportPlan, config: NoteshiftConfig) -> PreflightReport:
                 "Choose a directory path for out_dir."
             )
         elif any(out_dir.iterdir()) and not config.overwrite:
-            errors.append(f"Output dir {out_dir} is not empty. Use overwrite=True or choose a new out_dir.")
+            errors.append(
+                f"Output dir {out_dir} is not empty. "
+                "Use overwrite=True or choose a new out_dir."
+            )
 
     return PreflightReport(ok=not errors, errors=errors, warnings=warnings)
 
@@ -145,14 +155,20 @@ def run_export(
         except Exception as exc:  # noqa: BLE001
             msg = f"Failed to export page {page_id}: {exc}"
             all_errors.append(msg)
-            _emit(progress, ProgressEvent(type="error", id=page_id, title="page", message=msg))
+            _emit(
+                progress,
+                ProgressEvent(type="error", id=page_id, title="page", message=msg),
+            )
             if config.fail_fast:
                 raise RuntimeError(msg) from exc
 
     if plan.database_ids:
         client = NotionClient(token)
         for database_id in plan.database_ids:
-            _emit(progress, ProgressEvent(type="item_start", id=database_id, title="database"))
+            _emit(
+                progress,
+                ProgressEvent(type="item_start", id=database_id, title="database"),
+            )
             try:
                 schema = client.get_data_source(database_id)
                 title = _database_title(schema)
@@ -168,13 +184,26 @@ def run_export(
                     checkpoint.add_warning(warning)
                     _emit(
                         progress,
-                        ProgressEvent(type="warning", id=database_id, title="database", message=warning),
+                        ProgressEvent(
+                            type="warning",
+                            id=database_id,
+                            title="database",
+                            message=warning,
+                        ),
                     )
-                _emit(progress, ProgressEvent(type="item_done", id=database_id, title="database"))
+                _emit(
+                    progress,
+                    ProgressEvent(type="item_done", id=database_id, title="database"),
+                )
             except Exception as exc:  # noqa: BLE001
                 msg = f"Failed to export database {database_id}: {exc}"
                 all_errors.append(msg)
-                _emit(progress, ProgressEvent(type="error", id=database_id, title="database", message=msg))
+                _emit(
+                    progress,
+                    ProgressEvent(
+                        type="error", id=database_id, title="database", message=msg
+                    ),
+                )
                 if config.fail_fast:
                     raise RuntimeError(msg) from exc
 

--- a/src/noteshift/cli.py
+++ b/src/noteshift/cli.py
@@ -14,7 +14,9 @@ app = typer.Typer(add_completion=False, no_args_is_help=True)
 @app.command()
 def export(
     page_id: str = typer.Option(
-        ..., "--page-id", help="Root Notion page ID to export (UUID with or without dashes)."
+        ...,
+        "--page-id",
+        help="Root Notion page ID to export (UUID with or without dashes).",
     ),
     out: Path = typer.Option(
         Path("./out"), "--out", help="Output directory (will be created)."
@@ -29,16 +31,17 @@ def export(
         False, "--force", help="Force re-export of all items, ignoring checkpoint."
     ),
     overwrite: bool = typer.Option(
-        False, "--overwrite", help="Allow overwriting output directory even if not empty."
+        False,
+        "--overwrite",
+        help="Allow overwriting output directory even if not empty.",
     ),
     max_depth: int = typer.Option(
         2,
         "--max-depth",
         help="Maximum recursion depth to export. Set higher values for deeper trees.",
     ),
-
 ):
-    """Export a Notion page tree to Markdown (MVP: structure + toggles/children preserved)."""
+    """Export a Notion page tree to Markdown."""
 
     token = notion_token or os.getenv("NOTION_TOKEN") or ""
     out = out.resolve()

--- a/src/noteshift/db_export.py
+++ b/src/noteshift/db_export.py
@@ -47,7 +47,9 @@ def export_child_database(
 
     try:
         schema = client.get_data_source(data_source_id)
-        schema_path.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        schema_path.write_text(
+            json.dumps(schema, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
         files_written += 1
     except Exception as e:  # noqa: BLE001
         warnings.append(f"Failed to fetch schema for data source {data_source_id}: {e}")

--- a/src/noteshift/exporter.py
+++ b/src/noteshift/exporter.py
@@ -6,7 +6,12 @@ from pathlib import Path
 from noteshift.checkpoint import Checkpoint
 from noteshift.db_export import export_child_database
 from noteshift.filenames import FilenamePolicy, NameDeduper
-from noteshift.markdown import indent_lines, render_toggle, rich_text_plain, rich_text_to_markdown
+from noteshift.markdown import (
+    indent_lines,
+    render_toggle,
+    rich_text_plain,
+    rich_text_to_markdown,
+)
 from noteshift.notion import NotionClient
 
 
@@ -36,11 +41,15 @@ def _get_attachment_info(block: dict) -> tuple[str | None, str | None, str | Non
 
     if btype == "image":
         url = payload.get("file", {}).get("url")
-        caption = rich_text_to_markdown(payload.get("caption"), page_map={})  # No internal links in captions
+        caption = rich_text_to_markdown(
+            payload.get("caption"), page_map={}
+        )  # No internal links in captions
         return url, caption, "image"
     elif btype == "file":
         url = payload.get("file", {}).get("url")
-        caption = rich_text_to_markdown(payload.get("caption"), page_map={})  # No internal links in captions
+        caption = rich_text_to_markdown(
+            payload.get("caption"), page_map={}
+        )  # No internal links in captions
         return url, caption, "file"
     return None, None, None
 
@@ -111,7 +120,9 @@ def export_page_tree(
             if btype == "child_database":
                 ds_id = b.get("id")
                 if not ds_id:
-                    result.warnings.append(f"child_database missing id on page {page_id}")
+                    result.warnings.append(
+                        f"child_database missing id on page {page_id}"
+                    )
                     continue
 
                 # Skip if already exported (unless force mode)
@@ -142,7 +153,9 @@ def export_page_tree(
                 url, caption, _ = _get_attachment_info(b)
                 if url:
                     try:
-                        filename = Path(url.split("/")[-1].split("?")[0])  # Basic extraction
+                        filename = Path(
+                            url.split("/")[-1].split("?")[0]
+                        )  # Basic extraction
                         # Sanitize filename and ensure it's unique within _assets
                         sanitized_filename = Path(policy.slug(str(filename)))
                         deduped_filename = deduper.dedupe(str(sanitized_filename))
@@ -156,16 +169,24 @@ def export_page_tree(
                         asset_md_ref_str = asset_md_ref.as_posix()
 
                         if caption:
-                            rendered_content_lines.append(f"![{caption}]({asset_md_ref_str})")
+                            rendered_content_lines.append(
+                                f"![{caption}]({asset_md_ref_str})"
+                            )
                         else:
-                            rendered_content_lines.append(f"![{deduped_filename}]({asset_md_ref_str})")
+                            rendered_content_lines.append(
+                                f"![{deduped_filename}]({asset_md_ref_str})"
+                            )
 
                         result.attachments_downloaded += 1
 
                     except Exception as e:  # noqa: BLE001
-                        result.warnings.append(f"Failed to download attachment {url} for page {title}: {e}")
+                        result.warnings.append(
+                            f"Failed to download attachment {url} for page {title}: {e}"
+                        )
                 else:
-                    result.warnings.append(f"Attachment block missing URL or type on page {title}")
+                    result.warnings.append(
+                        f"Attachment block missing URL or type on page {title}"
+                    )
 
             else:
                 # For other block types, treat them as content to be rendered
@@ -244,9 +265,7 @@ def _render_blocks(
                 children = client.list_block_children(b["id"])
                 out.extend(
                     indent_lines(
-                        _render_blocks(
-                            client, children, indent="", page_map=page_map
-                        ),
+                        _render_blocks(client, children, indent="", page_map=page_map),
                         indent + "  ",
                     )
                 )
@@ -256,9 +275,12 @@ def _render_blocks(
             out.append(indent + f"1. {text}")
             if b.get("has_children"):
                 children = client.list_block_children(b["id"])
-                out.extend(indent_lines(
-                    _render_blocks(client, children, indent="", page_map=page_map), indent + "   "
-                ))
+                out.extend(
+                    indent_lines(
+                        _render_blocks(client, children, indent="", page_map=page_map),
+                        indent + "   ",
+                    )
+                )
 
         elif btype == "to_do":
             text = rich_text_to_markdown(payload.get("rich_text"), page_map)
@@ -269,9 +291,7 @@ def _render_blocks(
                 children = client.list_block_children(b["id"])
                 out.extend(
                     indent_lines(
-                        _render_blocks(
-                            client, children, indent="", page_map=page_map
-                        ),
+                        _render_blocks(client, children, indent="", page_map=page_map),
                         indent + "  ",
                     )
                 )
@@ -289,6 +309,8 @@ def _render_blocks(
             # For unhandled block types, preserve children if they exist
             if b.get("has_children"):
                 children = client.list_block_children(b["id"])
-                out.extend(_render_blocks(client, children, indent=indent, page_map=page_map))
+                out.extend(
+                    _render_blocks(client, children, indent=indent, page_map=page_map)
+                )
 
     return out

--- a/src/noteshift/license.py
+++ b/src/noteshift/license.py
@@ -14,10 +14,10 @@ if TYPE_CHECKING:
 
 def verify_license(key: str | None = None) -> dict:
     """Verify license and return feature limits.
-    
+
     Args:
         key: License key. If None or invalid, returns free tier limits.
-    
+
     Returns:
         dict with keys:
         - max_depth: int - maximum export depth (2 for free, 999 for paid)
@@ -27,26 +27,23 @@ def verify_license(key: str | None = None) -> dict:
     if key == "DEMO":
         return {
             "max_depth": 999,
-            "features": ["unlimited_depth", "checkpoint_resume", "migration_reports"]
+            "features": ["unlimited_depth", "checkpoint_resume", "migration_reports"],
         }
-    
+
     # Free tier
-    return {
-        "max_depth": 2,
-        "features": []
-    }
+    return {"max_depth": 2, "features": []}
 
 
 def check_depth_limit(current_depth: int, active_depth: int, has_license: bool) -> bool:
     """Check if children can be exported (would be at depth + 1).
-    
+
     Args:
         current_depth: Current recursion depth (0-indexed from root)
         active_depth: Maximum allowed depth from license
         has_license: Whether user has a valid license
-        
+
     Returns:
-        True if export should proceed (children at depth+1), False if depth limit reached
+        True when export should proceed. False when depth limit is reached.
     """
     if has_license:
         return True
@@ -56,11 +53,11 @@ def check_depth_limit(current_depth: int, active_depth: int, has_license: bool) 
 
 def get_depth_warning(current_depth: int, max_depth: int) -> str | None:
     """Get warning message when depth limit is reached for children.
-    
+
     Args:
         current_depth: Current recursion depth
         max_depth: Maximum allowed depth for this license tier
-        
+
     Returns:
         Warning message if children would exceed limit, None otherwise
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import pytest
 
 
 @pytest.fixture
-def mock_notion_client():
-    """Provides a mock NotionClient instance."""
-    client = MagicMock()
-    # You can configure mock client methods and return values here
-    # Example:
-    # client.pages.list.return_value = [
-    #     {"id": "123", "properties": {"Name": {"title": [{"text": {"content": "Test Page"}}]}}}
-    # ]
-    return client
+def mock_notion_client() -> MagicMock:
+    """Provide a mock Notion client instance for unit tests."""
+    return MagicMock()
 
-# Add other fixtures as needed, e.g., for specific page data, database structures, etc.
+
+@pytest.fixture(scope="module")
+def vcr_config() -> dict[str, object]:
+    """Configure pytest-vcr to scrub secret headers from cassettes."""
+    return {
+        "filter_headers": [("authorization", "DUMMY")],
+        "filter_query_parameters": [("token", "DUMMY")],
+        "record_mode": "none",
+    }

--- a/tests/contract/cassettes/test_get_page_contract_replay.yaml
+++ b/tests/contract/cassettes/test_get_page_contract_replay.yaml
@@ -1,0 +1,30 @@
+interactions:
+- request:
+    method: GET
+    uri: https://api.notion.com/v1/pages/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - DUMMY
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - python-httpx/0.28.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+    body:
+      string: '{"object":"page","id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","properties":{}}'
+version: 1

--- a/tests/contract/test_notion_contract.py
+++ b/tests/contract/test_notion_contract.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from noteshift.notion import NotionClient
+
+
+@pytest.mark.contract
+@pytest.mark.vcr(cassette_library_dir="tests/contract/cassettes")
+def test_get_page_contract_replay() -> None:
+    """Replay a deterministic Notion get page API interaction from cassette."""
+    client = NotionClient(token="secret_dummy")
+
+    payload = client.get_page("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    assert payload["id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    assert payload["object"] == "page"

--- a/tests/generate_notion_test_data.py
+++ b/tests/generate_notion_test_data.py
@@ -125,7 +125,10 @@ def main():
                     "type": "paragraph",
                     "paragraph": {
                         "rich_text": [
-                            {"type": "text", "text": {"content": f"Content for child {i}"}}
+                            {
+                                "type": "text",
+                                "text": {"content": f"Content for child {i}"},
+                            }
                         ]
                     },
                 },

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -27,7 +27,9 @@ def test_run_export_validation_errors(tmp_path: Path) -> None:
         run_export(plan, config)
 
 
-def test_run_export_emits_progress_events(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_run_export_emits_progress_events(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     events: list[str] = []
 
     def fake_export_page_tree(**_kwargs):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,8 +13,8 @@ runner = CliRunner()
 
 def _strip_ansi(text: str) -> str:
     """Remove ANSI escape sequences from text."""
-    ansi_escape = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
-    return ansi_escape.sub('', text)
+    ansi_escape = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+    return ansi_escape.sub("", text)
 
 
 class TestCLIHelp:
@@ -47,10 +47,7 @@ class TestExportValidation:
     @patch.dict("os.environ", {}, clear=True)
     def test_export_missing_token(self) -> None:
         """Export fails without token."""
-        result = runner.invoke(app, [
-            "export",
-            "--page-id", "test-page"
-        ])
+        result = runner.invoke(app, ["export", "--page-id", "test-page"])
         _ = _strip_ansi(result.output)  # noqa: F841
 
         assert result.exit_code != 0
@@ -62,11 +59,9 @@ class TestExportValidation:
         out_dir.mkdir()
         (out_dir / "file.txt").write_text("existing content")
 
-        result = runner.invoke(app, [
-            "export",
-            "--page-id", "test-page",
-            "--out", str(out_dir)
-        ])
+        result = runner.invoke(
+            app, ["export", "--page-id", "test-page", "--out", str(out_dir)]
+        )
         _ = _strip_ansi(result.output)  # noqa: F841
 
         assert result.exit_code != 0
@@ -80,14 +75,20 @@ class TestExportIntegration:
         """Basic export command accepts all flags."""
         # We can't easily test successful execution without mocking internals
         # This test verifies the command structure is valid
-        result = runner.invoke(app, [
-            "export",
-            "--page-id", "test-page",
-            "--out", "/tmp/test-out",
-            "--max-depth", "3",
-            "--force",
-            "--overwrite"
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "--page-id",
+                "test-page",
+                "--out",
+                "/tmp/test-out",
+                "--max-depth",
+                "3",
+                "--force",
+                "--overwrite",
+            ],
+        )
         _ = _strip_ansi(result.output)  # noqa: F841
 
         # Validates CLI parses all args without raising usage error

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -16,22 +16,21 @@ class TestExportPageTree:
         """Mock NotionClient with basic page structure."""
         with patch("noteshift.exporter.NotionClient") as mock:
             client = MagicMock()
-            
+
             # Mock get_page to return a page with title
             def get_page(page_id: str) -> dict:
                 return {
                     "id": page_id,
                     "properties": {
-                        "title": {
-                            "title": [{"text": {"content": f"Page {page_id}"}}]
-                        }
-                    }
+                        "title": {"title": [{"text": {"content": f"Page {page_id}"}}]}
+                    },
                 }
+
             client.get_page = get_page
-            
+
             # Mock list_block_children to return no children
             client.list_block_children.return_value = []
-            
+
             mock.return_value = client
             yield client
 
@@ -39,28 +38,34 @@ class TestExportPageTree:
     def minimal_checkpoint(self, tmp_path: Path):
         """Load a minimal checkpoint."""
         from noteshift.checkpoint import Checkpoint
+
         return Checkpoint.load(tmp_path / ".checkpoint.json")
 
-    def test_export_single_page(self, tmp_path: Path, mock_notion_client, minimal_checkpoint) -> None:
+    def test_export_single_page(
+        self, tmp_path: Path, mock_notion_client, minimal_checkpoint
+    ) -> None:
         """Export a single page with no children."""
         out_dir = tmp_path / "export"
-        
+
         result = export_page_tree(
             token="test-token",
             root_page_id="root-page",
             out_dir=out_dir,
             checkpoint=minimal_checkpoint,
         )
-        
+
         assert result.pages_exported == 1
         assert result.files_written == 1
         assert len(result.warnings) == 0
-        
+
         # Just check a directory was created (slug name varies)
         assert any(out_dir.iterdir())
 
-    def test_export_with_child_page(self, tmp_path: Path, mock_notion_client, minimal_checkpoint) -> None:
+    def test_export_with_child_page(
+        self, tmp_path: Path, mock_notion_client, minimal_checkpoint
+    ) -> None:
         """Export page with one child."""
+
         # Set up child page block
         def get_page(page_id: str) -> dict:
             titles = {
@@ -71,53 +76,60 @@ class TestExportPageTree:
                 "id": page_id,
                 "properties": {
                     "title": {
-                        "title": [{"text": {"content": titles.get(page_id, f"Page {page_id}")}}]
+                        "title": [
+                            {
+                                "text": {
+                                    "content": titles.get(page_id, f"Page {page_id}")
+                                }
+                            }
+                        ]
                     }
-                }
+                },
             }
-        
+
         mock_notion_client.get_page = get_page
-        
+
         # First call returns root with child, second call returns no children
         call_count = [0]
+
         def list_children(page_id: str) -> list:
             call_count[0] += 1
             if call_count[0] == 1:
                 return [{"id": "child-page", "type": "child_page"}]
             return []
+
         mock_notion_client.list_block_children = list_children
-        
+
         out_dir = tmp_path / "export"
-        
+
         result = export_page_tree(
             token="test-token",
             root_page_id="root-page",
             out_dir=out_dir,
             checkpoint=minimal_checkpoint,
         )
-        
+
         assert result.pages_exported == 2  # root + child
 
-    def test_depth_limit_free_tier(self, tmp_path: Path, mock_notion_client, minimal_checkpoint) -> None:
+    def test_depth_limit_free_tier(
+        self, tmp_path: Path, mock_notion_client, minimal_checkpoint
+    ) -> None:
         """Free tier stops at depth=2 with warning."""
         pages = {}
         page_counter = [0]
-        
+
         def get_page(page_id: str) -> dict:
             page_counter[0] += 1
             pages[page_id] = f"Page {page_counter[0]}"
             return {
                 "id": page_id,
                 "properties": {
-                    "title": {
-                        "title": [{"text": {"content": pages[page_id]}}]
-                    }
-                }
+                    "title": {"title": [{"text": {"content": pages[page_id]}}]}
+                },
             }
-        
+
         mock_notion_client.get_page = get_page
-        
-        # Create a deep chain: root -> child -> grandchild -> great-grandchild
+
         def list_children(page_id: str) -> list:
             depth = {"root": 0, "child": 1, "grandchild": 2}
             current_depth = depth.get(page_id, 3)
@@ -125,56 +137,59 @@ class TestExportPageTree:
                 next_id = ["child", "grandchild", "great-grandchild"][current_depth]
                 return [{"id": next_id, "type": "child_page"}]
             return []
-        
+
         mock_notion_client.list_block_children = list_children
-        
+
         out_dir = tmp_path / "export"
-        
+
         result = export_page_tree(
             token="test-token",
             root_page_id="root",
             out_dir=out_dir,
             checkpoint=minimal_checkpoint,
-            max_depth=2,  # Free tier
+            max_depth=2,
         )
-        
-        # Should export root (depth 0) + child (depth 1) + grandchild (depth 2) = 3 pages
-        # But not great-grandchild (depth 3)
+
         assert result.pages_exported == 3
         assert any("Depth limit" in w for w in result.warnings)
 
-    def test_depth_limit_high_max_depth(self, tmp_path: Path, mock_notion_client, minimal_checkpoint) -> None:
+    def test_depth_limit_high_max_depth(
+        self, tmp_path: Path, mock_notion_client, minimal_checkpoint
+    ) -> None:
         """High max_depth exports deeper trees."""
         pages = {}
         page_counter = [0]
-        
+
         def get_page(page_id: str) -> dict:
             page_counter[0] += 1
             pages[page_id] = f"Page {page_counter[0]}"
             return {
                 "id": page_id,
                 "properties": {
-                    "title": {
-                        "title": [{"text": {"content": pages[page_id]}}]
-                    }
-                }
+                    "title": {"title": [{"text": {"content": pages[page_id]}}]}
+                },
             }
-        
+
         mock_notion_client.get_page = get_page
-        
+
         # Create a deep chain
         def list_children(page_id: str) -> list:
             depth_map = {"root": 0, "child": 1, "grandchild": 2, "great-grandchild": 3}
             current_depth = depth_map.get(page_id, 4)
             if current_depth < 4:
-                next_ids = ["child", "grandchild", "great-grandchild", "great-great-grandchild"]
+                next_ids = [
+                    "child",
+                    "grandchild",
+                    "great-grandchild",
+                    "great-great-grandchild",
+                ]
                 return [{"id": next_ids[current_depth], "type": "child_page"}]
             return []
-        
+
         mock_notion_client.list_block_children = list_children
-        
+
         out_dir = tmp_path / "export"
-        
+
         result = export_page_tree(
             token="test-token",
             root_page_id="root",
@@ -187,15 +202,17 @@ class TestExportPageTree:
         assert result.pages_exported == 5
         assert not any("Depth limit" in w for w in result.warnings)
 
-    def test_force_mode_skips_checkpoint(self, tmp_path: Path, mock_notion_client) -> None:
+    def test_force_mode_skips_checkpoint(
+        self, tmp_path: Path, mock_notion_client
+    ) -> None:
         """Force mode re-exports already exported pages."""
         from noteshift.checkpoint import Checkpoint
-        
+
         checkpoint = Checkpoint()
         checkpoint.add_page("root-page")
-        
+
         out_dir = tmp_path / "export"
-        
+
         # Without force, root-page would be skipped
         result = export_page_tree(
             token="test-token",
@@ -204,7 +221,7 @@ class TestExportPageTree:
             checkpoint=checkpoint,
             force=True,
         )
-        
+
         assert result.pages_exported == 1  # Re-exported due to force
 
 
@@ -227,7 +244,7 @@ class TestExportResult:
         result.pages_exported += 5
         result.files_written += 5
         result.warnings.append("Test warning")
-        
+
         assert result.pages_exported == 5
         assert result.files_written == 5
         assert result.warnings == ["Test warning"]

--- a/tests/unit/test_filenames.py
+++ b/tests/unit/test_filenames.py
@@ -1,6 +1,5 @@
 """Tests for filename generation."""
 
-
 from noteshift.filenames import FilenamePolicy, NameDeduper
 
 
@@ -21,9 +20,9 @@ def test_filename_policy_windows_safe() -> None:
     """Test Windows-specific filename sanitization."""
     policy = FilenamePolicy()
     # Test invalid characters are replaced/removed
-    test_str_with_invalid = "File<>:\"/\\|?*\\x00\\x1fchars."
+    test_str_with_invalid = 'File<>:"/\\|?*\\x00\\x1fchars.'
     sanitized = policy.slug(test_str_with_invalid)
-    
+
     # Check that invalid characters are not present
     assert "<" not in sanitized
     assert ">" not in sanitized

--- a/tests/unit/test_license.py
+++ b/tests/unit/test_license.py
@@ -1,6 +1,5 @@
 """Tests for license module."""
 
-
 from noteshift.license import check_depth_limit, get_depth_warning, verify_license
 
 
@@ -73,4 +72,6 @@ class TestGetDepthWarning:
         """No warning for paid tier (never called in practice)."""
         # This wouldn't actually be called for paid users
         # But tests the behavior
-        assert get_depth_warning(999, 999) is not None  # Still returns warning at exact limit
+        assert (
+            get_depth_warning(999, 999) is not None
+        )  # Still returns warning at exact limit

--- a/tests/unit/test_markdown.py
+++ b/tests/unit/test_markdown.py
@@ -26,7 +26,11 @@ NOTION_RICH_TEXT_ITALIC = [
 ]
 
 NOTION_RICH_TEXT_CODE = [
-    {"type": "text", "annotations": {"code": True}, "text": {"content": "print('hello')"}},
+    {
+        "type": "text",
+        "annotations": {"code": True},
+        "text": {"content": "print('hello')"},
+    },
 ]
 
 NOTION_RICH_TEXT_LINK = [
@@ -41,7 +45,11 @@ NOTION_RICH_TEXT_LINK = [
 ]
 
 NOTION_RICH_TEXT_USER_MENTION = [
-    {"type": "mention", "mention": {"type": "user", "user": {"id": "user-456"}}, "plain_text": "John Doe"}
+    {
+        "type": "mention",
+        "mention": {"type": "user", "user": {"id": "user-456"}},
+        "plain_text": "John Doe",
+    }
 ]
 
 NOTION_RICH_TEXT_DATE_MENTION = [
@@ -106,13 +114,15 @@ def test_rich_text_to_markdown_date_mention():
 
 def test_rich_text_to_markdown_url_pipe_escape():
     """Test escaping pipe characters in link text."""
-    rt_with_pipe = [{
-        "type": "text",
-        "text": {
-            "content": "Link | With | Pipe",
-            "link": {"url": "https://example.com"}
+    rt_with_pipe = [
+        {
+            "type": "text",
+            "text": {
+                "content": "Link | With | Pipe",
+                "link": {"url": "https://example.com"},
+            },
         }
-    }]
+    ]
     expected = "[Link \\| With \\| Pipe](https://example.com)"
     assert rich_text_to_markdown(rt_with_pipe) == expected
 
@@ -134,7 +144,6 @@ def test_render_toggle():
         "Line 1",
         "Line 2",
         "",
-        "</details>"
+        "</details>",
     ]
     assert render_toggle(summary, body_lines) == expected
-

--- a/uv.lock
+++ b/uv.lock
@@ -194,6 +194,66 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -215,6 +275,48 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "noteshift"
 version = "0.1.0"
 source = { editable = "." }
@@ -226,25 +328,31 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-vcr" },
     { name = "ruff" },
 ]
 test = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-vcr" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.2" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
-    { name = "python-slugify", specifier = ">=8.0.4" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.4" },
-    { name = "typer", specifier = ">=0.24.1" },
+    { name = "httpx", specifier = ">=0.28.1,<0.29" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.1,<2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2,<10" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.2,<10" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0,<7" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0,<7" },
+    { name = "pytest-vcr", marker = "extra == 'dev'", specifier = ">=1.0.2,<2" },
+    { name = "pytest-vcr", marker = "extra == 'test'", specifier = ">=1.0.2,<2" },
+    { name = "python-slugify", specifier = ">=8.0.4,<9" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.4,<0.16" },
+    { name = "typer", specifier = ">=0.24.1,<1" },
 ]
 provides-extras = ["dev", "test"]
 
@@ -255,6 +363,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -293,16 +410,29 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
+]
+
+[[package]]
+name = "pytest-vcr"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "vcrpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/60/104c619483c1a42775d3f8b27293f1ecfc0728014874d065e68cb9702d49/pytest-vcr-1.0.2.tar.gz", hash = "sha256:23ee51b75abbcc43d926272773aae4f39f93aceb75ed56852d0bf618f92e1896", size = 3810, upload-time = "2019-04-26T19:04:00.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/d3/ff520d11e6ee400602711d1ece8168dcfc5b6d8146fb7db4244a6ad6a9c3/pytest_vcr-1.0.2-py2.py3-none-any.whl", hash = "sha256:2f316e0539399bea0296e8b8401145c62b6f85e9066af7e57b6151481b0d6d9c", size = 4137, upload-time = "2019-04-26T19:03:57.034Z" },
 ]
 
 [[package]]
@@ -315,6 +445,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]
@@ -395,4 +571,71 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "vcrpy"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/07/bcfd5ebd7cb308026ab78a353e091bd699593358be49197d39d004e5ad83/vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f", size = 85770, upload-time = "2026-01-04T19:22:03.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/d7/f79b05a5d728f8786876a7d75dfb0c5cae27e428081b2d60152fb52f155f/vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9", size = 42445, upload-time = "2026-01-04T19:22:02.532Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/37/ae31f40bec90de2f88d9597d0b5281e23ffe85b893a47ca5d9c05c63a4f6/wrapt-2.1.1.tar.gz", hash = "sha256:5fdcb09bf6db023d88f312bd0767594b414655d58090fc1c46b3414415f67fac", size = 81329, upload-time = "2026-02-03T02:12:13.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/cb/4d5255d19bbd12be7f8ee2c1fb4269dddec9cef777ef17174d357468efaa/wrapt-2.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab8e3793b239db021a18782a5823fcdea63b9fe75d0e340957f5828ef55fcc02", size = 61143, upload-time = "2026-02-03T02:11:46.313Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/07/7ed02daa35542023464e3c8b7cb937fa61f6c61c0361ecf8f5fecf8ad8da/wrapt-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c0300007836373d1c2df105b40777986accb738053a92fe09b615a7a4547e9f", size = 61740, upload-time = "2026-02-03T02:12:51.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/60/a237a4e4a36f6d966061ccc9b017627d448161b19e0a3ab80a7c7c97f859/wrapt-2.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2b27c070fd1132ab23957bcd4ee3ba707a91e653a9268dc1afbd39b77b2799f7", size = 121327, upload-time = "2026-02-03T02:11:06.796Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/fe/9139058a3daa8818fc67e6460a2340e8bbcf3aef8b15d0301338bbe181ca/wrapt-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b0e36d845e8b6f50949b6b65fc6cd279f47a1944582ed4ec8258cd136d89a64", size = 122903, upload-time = "2026-02-03T02:12:48.657Z" },
+    { url = "https://files.pythonhosted.org/packages/91/10/b8479202b4164649675846a531763531f0a6608339558b5a0a718fc49a8d/wrapt-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4aeea04a9889370fcfb1ef828c4cc583f36a875061505cd6cd9ba24d8b43cc36", size = 121333, upload-time = "2026-02-03T02:11:32.148Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/75fc793b791d79444aca2c03ccde64e8b99eda321b003f267d570b7b0985/wrapt-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d88b46bb0dce9f74b6817bc1758ff2125e1ca9e1377d62ea35b6896142ab6825", size = 120458, upload-time = "2026-02-03T02:11:16.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8f/c3f30d511082ca6d947c405f9d8f6c8eaf83cfde527c439ec2c9a30eb5ea/wrapt-2.1.1-cp312-cp312-win32.whl", hash = "sha256:63decff76ca685b5c557082dfbea865f3f5f6d45766a89bff8dc61d336348833", size = 58086, upload-time = "2026-02-03T02:12:35.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c8/37625b643eea2849f10c3b90f69c7462faa4134448d4443234adaf122ae5/wrapt-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b828235d26c1e35aca4107039802ae4b1411be0fe0367dd5b7e4d90e562fcbcd", size = 60328, upload-time = "2026-02-03T02:12:45.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/79/56242f07572d5682ba8065a9d4d9c2218313f576e3c3471873c2a5355ffd/wrapt-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:75128507413a9f1bcbe2db88fd18fbdbf80f264b82fa33a6996cdeaf01c52352", size = 58722, upload-time = "2026-02-03T02:12:27.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3cf290212855b19af9fcc41b725b5620b32f470d6aad970c2593500817eb/wrapt-2.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ce9646e17fa7c3e2e7a87e696c7de66512c2b4f789a8db95c613588985a2e139", size = 61150, upload-time = "2026-02-03T02:12:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/33/5b8f89a82a9859ce82da4870c799ad11ce15648b6e1c820fec3e23f4a19f/wrapt-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:428cfc801925454395aa468ba7ddb3ed63dc0d881df7b81626cdd433b4e2b11b", size = 61743, upload-time = "2026-02-03T02:11:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2f/60c51304fbdf47ce992d9eefa61fbd2c0e64feee60aaa439baf42ea6f40b/wrapt-2.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5797f65e4d58065a49088c3b32af5410751cd485e83ba89e5a45e2aa8905af98", size = 121341, upload-time = "2026-02-03T02:11:20.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/03/ce5256e66dd94e521ad5e753c78185c01b6eddbed3147be541f4d38c0cb7/wrapt-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a2db44a71202c5ae4bb5f27c6d3afbc5b23053f2e7e78aa29704541b5dad789", size = 122947, upload-time = "2026-02-03T02:11:33.596Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/50ca8854b81b946a11a36fcd6ead32336e6db2c14b6e4a8b092b80741178/wrapt-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8d5350c3590af09c1703dd60ec78a7370c0186e11eaafb9dda025a30eee6492d", size = 121370, upload-time = "2026-02-03T02:11:09.886Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d9/d6a7c654e0043319b4cc137a4caaf7aa16b46b51ee8df98d1060254705b7/wrapt-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d9b076411bed964e752c01b49fd224cc385f3a96f520c797d38412d70d08359", size = 120465, upload-time = "2026-02-03T02:11:37.592Z" },
+    { url = "https://files.pythonhosted.org/packages/55/90/65be41e40845d951f714b5a77e84f377a3787b1e8eee6555a680da6d0db5/wrapt-2.1.1-cp313-cp313-win32.whl", hash = "sha256:0bb7207130ce6486727baa85373503bf3334cc28016f6928a0fa7e19d7ecdc06", size = 58090, upload-time = "2026-02-03T02:12:53.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/66/6a09e0294c4fc8c26028a03a15191721c9271672467cc33e6617ee0d91d2/wrapt-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:cbfee35c711046b15147b0ae7db9b976f01c9520e6636d992cd9e69e5e2b03b1", size = 60341, upload-time = "2026-02-03T02:12:36.384Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/20ceb8b701e9a71555c87a5ddecbed76ec16742cf1e4b87bbaf26735f998/wrapt-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:7d2756061022aebbf57ba14af9c16e8044e055c22d38de7bf40d92b565ecd2b0", size = 58731, upload-time = "2026-02-03T02:12:01.328Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b4/fe95beb8946700b3db371f6ce25115217e7075ca063663b8cca2888ba55c/wrapt-2.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4814a3e58bc6971e46baa910ecee69699110a2bf06c201e24277c65115a20c20", size = 62969, upload-time = "2026-02-03T02:11:51.245Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/89/477b0bdc784e3299edf69c279697372b8bd4c31d9c6966eae405442899df/wrapt-2.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:106c5123232ab9b9f4903692e1fa0bdc231510098f04c13c3081f8ad71c3d612", size = 63606, upload-time = "2026-02-03T02:12:02.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/55/9d0c1269ab76de87715b3b905df54dd25d55bbffd0b98696893eb613469f/wrapt-2.1.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1a40b83ff2535e6e56f190aff123821eea89a24c589f7af33413b9c19eb2c738", size = 152536, upload-time = "2026-02-03T02:11:24.492Z" },
+    { url = "https://files.pythonhosted.org/packages/44/18/2004766030462f79ad86efaa62000b5e39b1ff001dcce86650e1625f40ae/wrapt-2.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:789cea26e740d71cf1882e3a42bb29052bc4ada15770c90072cb47bf73fb3dbf", size = 158697, upload-time = "2026-02-03T02:12:32.214Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/bb/0a880fa0f35e94ee843df4ee4dd52a699c9263f36881311cfb412c09c3e5/wrapt-2.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ba49c14222d5e5c0ee394495a8655e991dc06cbca5398153aefa5ac08cd6ccd7", size = 155563, upload-time = "2026-02-03T02:11:49.737Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/cd1b7c4846c8678fac359a6eb975dc7ab5bd606030adb22acc8b4a9f53f1/wrapt-2.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ac8cda531fe55be838a17c62c806824472bb962b3afa47ecbd59b27b78496f4e", size = 150161, upload-time = "2026-02-03T02:12:33.613Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ec/67c90a7082f452964b4621e4890e9a490f1add23cdeb7483cc1706743291/wrapt-2.1.1-cp313-cp313t-win32.whl", hash = "sha256:b8af75fe20d381dd5bcc9db2e86a86d7fcfbf615383a7147b85da97c1182225b", size = 59783, upload-time = "2026-02-03T02:11:39.863Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/08/466afe4855847d8febdfa2c57c87e991fc5820afbdef01a273683dfd15a0/wrapt-2.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:45c5631c9b6c792b78be2d7352129f776dd72c605be2c3a4e9be346be8376d83", size = 63082, upload-time = "2026-02-03T02:12:09.075Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/62/60b629463c28b15b1eeadb3a0691e17568622b12aa5bfa7ebe9b514bfbeb/wrapt-2.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:da815b9263947ac98d088b6414ac83507809a1d385e4632d9489867228d6d81c", size = 60251, upload-time = "2026-02-03T02:11:21.794Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a0/1c2396e272f91efe6b16a6a8bce7ad53856c8f9ae4f34ceaa711d63ec9e1/wrapt-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aa1765054245bb01a37f615503290d4e207e3fd59226e78341afb587e9c1236", size = 61311, upload-time = "2026-02-03T02:12:44.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/9a/d2faba7e61072a7507b5722db63562fdb22f5a24e237d460d18755627f15/wrapt-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:feff14b63a6d86c1eee33a57f77573649f2550935981625be7ff3cb7342efe05", size = 61805, upload-time = "2026-02-03T02:11:59.905Z" },
+    { url = "https://files.pythonhosted.org/packages/db/56/073989deb4b5d7d6e7ea424476a4ae4bda02140f2dbeaafb14ba4864dd60/wrapt-2.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81fc5f22d5fcfdbabde96bb3f5379b9f4476d05c6d524d7259dc5dfb501d3281", size = 120308, upload-time = "2026-02-03T02:12:04.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b6/84f37261295e38167a29eb82affaf1dc15948dc416925fe2091beee8e4ac/wrapt-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951b228ecf66def855d22e006ab9a1fc12535111ae7db2ec576c728f8ddb39e8", size = 122688, upload-time = "2026-02-03T02:11:23.148Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/80/32db2eec6671f80c65b7ff175be61bc73d7f5223f6910b0c921bbc4bd11c/wrapt-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ddf582a95641b9a8c8bd643e83f34ecbbfe1b68bc3850093605e469ab680ae3", size = 121115, upload-time = "2026-02-03T02:12:39.068Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ef/dcd00383df0cd696614127902153bf067971a5aabcd3c9dcb2d8ef354b2a/wrapt-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fc5c500966bf48913f795f1984704e6d452ba2414207b15e1f8c339a059d5b16", size = 119484, upload-time = "2026-02-03T02:11:48.419Z" },
+    { url = "https://files.pythonhosted.org/packages/76/29/0630280cdd2bd8f86f35cb6854abee1c9d6d1a28a0c6b6417cd15d378325/wrapt-2.1.1-cp314-cp314-win32.whl", hash = "sha256:4aa4baadb1f94b71151b8e44a0c044f6af37396c3b8bcd474b78b49e2130a23b", size = 58514, upload-time = "2026-02-03T02:11:58.616Z" },
+    { url = "https://files.pythonhosted.org/packages/db/19/5bed84f9089ed2065f6aeda5dfc4f043743f642bc871454b261c3d7d322b/wrapt-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:860e9d3fd81816a9f4e40812f28be4439ab01f260603c749d14be3c0a1170d19", size = 60763, upload-time = "2026-02-03T02:12:24.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/b967f2f9669e4249b4fe82e630d2a01bc6b9e362b9b12ed91bbe23ae8df4/wrapt-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3c59e103017a2c1ea0ddf589cbefd63f91081d7ce9d491d69ff2512bb1157e23", size = 59051, upload-time = "2026-02-03T02:11:29.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/19/6fed62be29f97eb8a56aff236c3f960a4b4a86e8379dc7046a8005901a97/wrapt-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9fa7c7e1bee9278fc4f5dd8275bc8d25493281a8ec6c61959e37cc46acf02007", size = 63059, upload-time = "2026-02-03T02:12:06.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1c/b757fd0adb53d91547ed8fad76ba14a5932d83dde4c994846a2804596378/wrapt-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39c35e12e8215628984248bd9c8897ce0a474be2a773db207eb93414219d8469", size = 63618, upload-time = "2026-02-03T02:12:23.197Z" },
+    { url = "https://files.pythonhosted.org/packages/10/fe/e5ae17b1480957c7988d991b93df9f2425fc51f128cf88144d6a18d0eb12/wrapt-2.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:94ded4540cac9125eaa8ddf5f651a7ec0da6f5b9f248fe0347b597098f8ec14c", size = 152544, upload-time = "2026-02-03T02:11:43.915Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cc/99aed210c6b547b8a6e4cb9d1425e4466727158a6aeb833aa7997e9e08dd/wrapt-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da0af328373f97ed9bdfea24549ac1b944096a5a71b30e41c9b8b53ab3eec04a", size = 158700, upload-time = "2026-02-03T02:12:30.684Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/d442f745f4957944d5f8ad38bc3a96620bfff3562533b87e486e979f3d99/wrapt-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4ad839b55f0bf235f8e337ce060572d7a06592592f600f3a3029168e838469d3", size = 155561, upload-time = "2026-02-03T02:11:28.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/9891816280e0018c48f8dfd61b136af7b0dcb4a088895db2531acde5631b/wrapt-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d89c49356e5e2a50fa86b40e0510082abcd0530f926cbd71cf25bee6b9d82d7", size = 150188, upload-time = "2026-02-03T02:11:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/e2f273b6d70d41f98d0739aa9a269d0b633684a5fb17b9229709375748d4/wrapt-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:f4c7dd22cf7f36aafe772f3d88656559205c3af1b7900adfccb70edeb0d2abc4", size = 60425, upload-time = "2026-02-03T02:11:35.007Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/06/b500bfc38a4f82d89f34a13069e748c82c5430d365d9e6b75afb3ab74457/wrapt-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f76bc12c583ab01e73ba0ea585465a41e48d968f6d1311b4daec4f8654e356e3", size = 63855, upload-time = "2026-02-03T02:12:15.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cc/5f6193c32166faee1d2a613f278608e6f3b95b96589d020f0088459c46c9/wrapt-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7ea74fc0bec172f1ae5f3505b6655c541786a5cabe4bbc0d9723a56ac32eb9b9", size = 60443, upload-time = "2026-02-03T02:11:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/da/5a086bf4c22a41995312db104ec2ffeee2cf6accca9faaee5315c790377d/wrapt-2.1.1-py3-none-any.whl", hash = "sha256:3b0f4629eb954394a3d7c7a1c8cca25f0b07cefe6aa8545e862e9778152de5b7", size = 43886, upload-time = "2026-02-03T02:11:45.048Z" },
 ]


### PR DESCRIPTION
Implements the first major readiness tranche from the epic tracker.

Addresses:
- #4 (epic foundation)
- #6 OSS baseline docs + metadata
- #7 README/docs refresh
- #9 customer pain map
- #10 pytest-vcr contract harness
- #12 release checklist foundation

Includes:
- complete OSS baseline files (LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG)
- refreshed README with accurate env var/CLI usage and contract test guidance
- updated package metadata and project URLs for Fragment256 target ownership
- CI workflow hardening (format/lint/test matrix, contract test lane, coverage threshold baseline)
- deterministic pytest-vcr contract test + sanitized cassette
- customer pain map and release checklist docs
- transfer execution plan doc for #5

Notes:
- Type-checking is included as a baseline step and currently non-blocking while debt is burned down in #8.
- Coverage threshold is raised to a practical baseline (55%) and should be ratcheted upward in #8/#11 work.
