### PR TITLE
CI hardening: blocking mypy, higher coverage floor, and expanded validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,11 @@ jobs:
       - name: Ruff lint
         run: uv run ruff check .
 
-      - name: Type check (baseline)
+      - name: Type check
         run: uv run mypy src
-        continue-on-error: true
 
       - name: Unit and integration tests
-        run: uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=55 tests/
+        run: uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=58 tests/
 
       - name: Contract tests (vcr replay)
         run: uv run pytest -m contract

--- a/src/noteshift/api.py
+++ b/src/noteshift/api.py
@@ -22,7 +22,7 @@ def _write_migration_report(
     out_dir: Path, checkpoint: Checkpoint
 ) -> tuple[Path, list[str]]:
     report_errors: list[str] = []
-    report_data = {
+    report_data: dict[str, object] = {
         "timestamp": datetime.now(UTC).isoformat(),
         "pages_exported_total": len(checkpoint.page_ids),
         "databases_exported_total": len(checkpoint.database_ids),
@@ -58,8 +58,9 @@ def _write_migration_report(
             "## Warnings",
             "",
         ]
-        if report_data["warnings"]:
-            for warning in report_data["warnings"]:
+        warnings = report_data["warnings"]
+        if isinstance(warnings, list) and warnings:
+            for warning in warnings:
                 md_lines.append(f"- {warning}")
         else:
             md_lines.append("No warnings.")

--- a/src/noteshift/db_export.py
+++ b/src/noteshift/db_export.py
@@ -13,6 +13,7 @@ class DataSourceExportResult:
     data_sources_exported: int
     rows_exported: int
     files_written: int
+    attachments_downloaded: int
     warnings: list[str]
 
 
@@ -86,5 +87,6 @@ def export_child_database(
         data_sources_exported=1,
         rows_exported=len(rows),
         files_written=files_written,
+        attachments_downloaded=0,
         warnings=warnings,
     )

--- a/src/noteshift/exporter.py
+++ b/src/noteshift/exporter.py
@@ -42,13 +42,13 @@ def _get_attachment_info(block: dict) -> tuple[str | None, str | None, str | Non
     if btype == "image":
         url = payload.get("file", {}).get("url")
         caption = rich_text_to_markdown(
-            payload.get("caption"), page_map={}
+            payload.get("caption"), page_mapper=None
         )  # No internal links in captions
         return url, caption, "image"
     elif btype == "file":
         url = payload.get("file", {}).get("url")
         caption = rich_text_to_markdown(
-            payload.get("caption"), page_map={}
+            payload.get("caption"), page_mapper=None
         )  # No internal links in captions
         return url, caption, "file"
     return None, None, None
@@ -78,6 +78,7 @@ def export_page_tree(
     page_map: dict[str, str] = {}
 
     result = ExportResult()
+    active_checkpoint = checkpoint or Checkpoint()
 
     visited: set[str] = set()
     depth_limited_ids: set[str] = set()
@@ -89,7 +90,7 @@ def export_page_tree(
         visited.add(page_id)
 
         # Skip if already exported (unless force mode)
-        if not force and checkpoint.is_page_exported(page_id):
+        if not force and active_checkpoint.is_page_exported(page_id):
             return
 
         page = client.get_page(page_id)
@@ -126,7 +127,7 @@ def export_page_tree(
                     continue
 
                 # Skip if already exported (unless force mode)
-                if not force and checkpoint.is_database_exported(ds_id):
+                if not force and active_checkpoint.is_database_exported(ds_id):
                     continue
 
                 title_db = (b.get("child_database") or {}).get("title") or "Database"
@@ -143,11 +144,10 @@ def export_page_tree(
                 result.attachments_downloaded += res.attachments_downloaded
 
                 # Update checkpoint
-                checkpoint.add_database(ds_id)
-                checkpoint.add_rows(res.rows_exported)
+                active_checkpoint.add_database(ds_id)
+                active_checkpoint.add_rows(res.rows_exported)
                 for w in res.warnings:
-                    checkpoint.add_warning(w)
-                result._exported_database_ids.append(ds_id)
+                    active_checkpoint.add_warning(w)
 
             elif btype in {"image", "file"}:
                 url, caption, _ = _get_attachment_info(b)
@@ -205,8 +205,8 @@ def export_page_tree(
         result.files_written += 1  # Count the markdown file itself
 
         # Update checkpoint
-        checkpoint.add_page(page_id)
-        checkpoint.add_file(str(md_path.relative_to(out_dir)))
+        active_checkpoint.add_page(page_id)
+        active_checkpoint.add_file(str(md_path.relative_to(out_dir)))
 
         # recurse into child pages (depth limit check)
         if max_depth >= 0 and depth + 1 > max_depth:
@@ -247,19 +247,19 @@ def _render_blocks(
             continue
 
         if btype == "paragraph":
-            text = rich_text_to_markdown(payload.get("rich_text"), page_map)
+            text = rich_text_to_markdown(payload.get("rich_text"), page_map.get)
             if text:
                 out.append(indent + text)
                 out.append("")
 
         elif btype in {"heading_1", "heading_2", "heading_3"}:
             level = {"heading_1": "#", "heading_2": "##", "heading_3": "###"}[btype]
-            text = rich_text_to_markdown(payload.get("rich_text"), page_map)
+            text = rich_text_to_markdown(payload.get("rich_text"), page_map.get)
             out.append(indent + f"{level} {text}")
             out.append("")
 
         elif btype == "bulleted_list_item":
-            text = rich_text_to_markdown(payload.get("rich_text"), page_map)
+            text = rich_text_to_markdown(payload.get("rich_text"), page_map.get)
             out.append(indent + f"- {text}")
             if b.get("has_children"):
                 children = client.list_block_children(b["id"])
@@ -271,7 +271,7 @@ def _render_blocks(
                 )
 
         elif btype == "numbered_list_item":
-            text = rich_text_to_markdown(payload.get("rich_text"), page_map)
+            text = rich_text_to_markdown(payload.get("rich_text"), page_map.get)
             out.append(indent + f"1. {text}")
             if b.get("has_children"):
                 children = client.list_block_children(b["id"])
@@ -283,7 +283,7 @@ def _render_blocks(
                 )
 
         elif btype == "to_do":
-            text = rich_text_to_markdown(payload.get("rich_text"), page_map)
+            text = rich_text_to_markdown(payload.get("rich_text"), page_map.get)
             checked = payload.get("checked")
             box = "x" if checked else " "
             out.append(indent + f"- [{box}] {text}")
@@ -297,7 +297,7 @@ def _render_blocks(
                 )
 
         elif btype == "toggle":
-            summary = rich_text_to_markdown(payload.get("rich_text"), page_map)
+            summary = rich_text_to_markdown(payload.get("rich_text"), page_map.get)
             body: list[str] = []
             if b.get("has_children"):
                 children = client.list_block_children(b["id"])

--- a/src/noteshift/notion.py
+++ b/src/noteshift/notion.py
@@ -31,7 +31,7 @@ class NotionClient:
         cursor: str | None = None
         with httpx.Client(timeout=30.0, headers=self._headers()) as client:
             while True:
-                params: dict[str, object] = {"page_size": 100}
+                params: dict[str, str | int] = {"page_size": 100}
                 if cursor:
                     params["start_cursor"] = cursor
                 url = f"https://api.notion.com/v1/blocks/{block_id}/children"

--- a/tests/contract/cassettes/test_query_data_source_contract_replay.yaml
+++ b/tests/contract/cassettes/test_query_data_source_contract_replay.yaml
@@ -1,0 +1,32 @@
+interactions:
+- request:
+    method: POST
+    uri: https://api.notion.com/v1/data_sources/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/query
+    body: '{"page_size":100}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - DUMMY
+      connection:
+      - keep-alive
+      content-length:
+      - '17'
+      content-type:
+      - application/json
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - python-httpx/0.28.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+    body:
+      string: '{"results":[{"id":"row-1"},{"id":"row-2"}],"has_more":false}'
+version: 1

--- a/tests/contract/test_notion_contract_query.py
+++ b/tests/contract/test_notion_contract_query.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from noteshift.notion import NotionClient
+
+
+@pytest.mark.contract
+@pytest.mark.vcr(cassette_library_dir="tests/contract/cassettes")
+def test_query_data_source_contract_replay() -> None:
+    """Replay deterministic query interaction from cassette."""
+    client = NotionClient(token="secret_dummy")
+
+    rows = client.query_data_source("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    assert len(rows) == 2
+    assert rows[0]["id"] == "row-1"

--- a/tests/integration/test_export_smoke.py
+++ b/tests/integration/test_export_smoke.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from noteshift.api import run_export
+from noteshift.types import ExportPlan, NoteshiftConfig
+
+
+def test_run_export_writes_report_and_checkpoint(monkeypatch, tmp_path: Path) -> None:
+    def fake_export_page_tree(**kwargs):
+        checkpoint = kwargs["checkpoint"]
+        checkpoint.add_page(kwargs["root_page_id"])
+        checkpoint.add_file("root/index.md")
+        return None
+
+    monkeypatch.setattr("noteshift.api.export_page_tree", fake_export_page_tree)
+
+    config = NoteshiftConfig(
+        notion_token="test-token",
+        out_dir=tmp_path / "out",
+        overwrite=True,
+    )
+    plan = ExportPlan(page_ids=["root-page-id"], database_ids=[])
+
+    result = run_export(plan, config)
+
+    assert result.pages_exported == 1
+    assert result.checkpoint_path is not None
+    assert result.checkpoint_path.exists()
+    assert result.report_path.exists()
+
+
+def test_run_export_respects_fail_fast(monkeypatch, tmp_path: Path) -> None:
+    def fake_export_page_tree(**_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("noteshift.api.export_page_tree", fake_export_page_tree)
+
+    config = NoteshiftConfig(
+        notion_token="test-token",
+        out_dir=tmp_path / "out",
+        overwrite=True,
+        fail_fast=True,
+    )
+    plan = ExportPlan(page_ids=["root-page-id"], database_ids=[])
+
+    try:
+        run_export(plan, config)
+    except RuntimeError as exc:
+        assert "Failed to export page" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError in fail_fast mode")


### PR DESCRIPTION
Progresses readiness issues:\n- #8 CI hardening\n- #10 contract validation expansion\n- #11 integration/e2e smoke validation\n\nWhat changed:\n- fixed mypy errors across export/notion/api paths\n- made mypy blocking in CI\n- raised coverage gate from 55% -> 58%\n- added deterministic integration smoke tests for export flow and fail_fast behavior\n- expanded pytest-vcr contracts with data source query replay test\n\nValidation run locally:\n- ruff format/check\n- mypy src\n- pytest with coverage (62%)\n- pytest -m contract