### PR TITLE
Coverage ratchet to 65% + core module test expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv run mypy src
 
       - name: Unit and integration tests
-        run: uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=58 tests/
+        run: uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=65 tests/
 
       - name: Contract tests (vcr replay)
         run: uv run pytest -m contract

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,95 +1,163 @@
-"""Tests for CLI module."""
+from __future__ import annotations
 
-import re
 from pathlib import Path
-from unittest.mock import patch
 
 from typer.testing import CliRunner
 
 from noteshift.cli import app
+from noteshift.types import ExportResult, PreflightReport
 
 runner = CliRunner()
 
 
-def _strip_ansi(text: str) -> str:
-    """Remove ANSI escape sequences from text."""
-    ansi_escape = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
-    return ansi_escape.sub("", text)
+def _ok_result(tmp_path: Path) -> ExportResult:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report_path = out_dir / "migration_report.json"
+    report_path.write_text("{}", encoding="utf-8")
+    checkpoint_path = out_dir / ".checkpoint.json"
+    checkpoint_path.write_text("{}", encoding="utf-8")
+    return ExportResult(
+        out_dir=out_dir,
+        report_path=report_path,
+        checkpoint_path=checkpoint_path,
+        pages_exported=1,
+        databases_exported=0,
+        rows_exported=0,
+        attachments_downloaded=0,
+        warnings=[],
+        errors=[],
+    )
 
 
-class TestCLIHelp:
-    """Tests for CLI help messages."""
+def test_export_success(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "noteshift.cli.preflight",
+        lambda _plan, _config: PreflightReport(ok=True),
+    )
+    monkeypatch.setattr(
+        "noteshift.cli.run_export", lambda **_kwargs: _ok_result(tmp_path)
+    )
 
-    def test_main_help(self) -> None:
-        """Main help shows available commands."""
-        result = runner.invoke(app, ["--help"])
-        output = _strip_ansi(result.output)
+    result = runner.invoke(
+        app,
+        [
+            "--page-id",
+            "page-1",
+            "--out",
+            str(tmp_path / "out"),
+            "--notion-token",
+            "secret",
+        ],
+    )
 
-        assert result.exit_code == 0
-        assert "export" in output
-
-    def test_export_help(self) -> None:
-        """Export command help shows all options."""
-        result = runner.invoke(app, ["export", "--help"])
-        output = _strip_ansi(result.output)
-
-        assert result.exit_code == 0
-        assert "--page-id" in output
-        assert "--out" in output
-        assert "--max-depth" in output
-        assert "--force" in output
-        assert "--overwrite" in output
-
-
-class TestExportValidation:
-    """Tests for export command validation."""
-
-    @patch.dict("os.environ", {}, clear=True)
-    def test_export_missing_token(self) -> None:
-        """Export fails without token."""
-        result = runner.invoke(app, ["export", "--page-id", "test-page"])
-        _ = _strip_ansi(result.output)  # noqa: F841
-
-        assert result.exit_code != 0
-
-    @patch.dict("os.environ", {"NOTION_TOKEN": "test-token"}, clear=True)
-    def test_export_existing_output_without_overwrite(self, tmp_path: Path) -> None:
-        """Export fails if output exists and --overwrite not set."""
-        out_dir = tmp_path / "existing"
-        out_dir.mkdir()
-        (out_dir / "file.txt").write_text("existing content")
-
-        result = runner.invoke(
-            app, ["export", "--page-id", "test-page", "--out", str(out_dir)]
-        )
-        _ = _strip_ansi(result.output)  # noqa: F841
-
-        assert result.exit_code != 0
+    assert result.exit_code == 0
+    assert "Export complete." in result.output
+    assert "Pages exported: 1" in result.output
 
 
-class TestExportIntegration:
-    """Integration tests that mock export_page_tree."""
+def test_export_preflight_failure(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "noteshift.cli.preflight",
+        lambda _plan, _config: PreflightReport(ok=False, errors=["bad input"]),
+    )
 
-    @patch.dict("os.environ", {"NOTION_TOKEN": "test-token"}, clear=True)
-    def test_export_basic_args(self) -> None:
-        """Basic export command accepts all flags."""
-        # We can't easily test successful execution without mocking internals
-        # This test verifies the command structure is valid
-        result = runner.invoke(
-            app,
-            [
-                "export",
-                "--page-id",
-                "test-page",
-                "--out",
-                "/tmp/test-out",
-                "--max-depth",
-                "3",
-                "--force",
-                "--overwrite",
-            ],
-        )
-        _ = _strip_ansi(result.output)  # noqa: F841
+    result = runner.invoke(
+        app,
+        [
+            "--page-id",
+            "page-1",
+            "--out",
+            str(tmp_path / "out"),
+            "--notion-token",
+            "secret",
+        ],
+    )
 
-        # Validates CLI parses all args without raising usage error
-        assert result.exit_code != 0  # Will fail due to no real mock, that's expected
+    assert result.exit_code != 0
+    assert "bad input" in result.output
+
+
+def test_export_force_mode_message(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "noteshift.cli.preflight",
+        lambda _plan, _config: PreflightReport(ok=True),
+    )
+    monkeypatch.setattr(
+        "noteshift.cli.run_export", lambda **_kwargs: _ok_result(tmp_path)
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--page-id",
+            "page-1",
+            "--out",
+            str(tmp_path / "out"),
+            "--notion-token",
+            "secret",
+            "--force",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Force mode enabled" in result.output
+
+
+def test_export_errors_exit_nonzero(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "noteshift.cli.preflight",
+        lambda _plan, _config: PreflightReport(ok=True),
+    )
+
+    def failed_result(**_kwargs) -> ExportResult:
+        result = _ok_result(tmp_path)
+        result.errors = ["failure one"]
+        return result
+
+    monkeypatch.setattr("noteshift.cli.run_export", failed_result)
+
+    result = runner.invoke(
+        app,
+        [
+            "--page-id",
+            "page-1",
+            "--out",
+            str(tmp_path / "out"),
+            "--notion-token",
+            "secret",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Export failed with errors." in result.output
+
+
+def test_export_shows_warnings(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "noteshift.cli.preflight",
+        lambda _plan, _config: PreflightReport(ok=True),
+    )
+
+    def warned_result(**_kwargs) -> ExportResult:
+        result = _ok_result(tmp_path)
+        result.warnings = ["warn one"]
+        return result
+
+    monkeypatch.setattr("noteshift.cli.run_export", warned_result)
+
+    result = runner.invoke(
+        app,
+        [
+            "--page-id",
+            "page-1",
+            "--out",
+            str(tmp_path / "out"),
+            "--notion-token",
+            "secret",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Warnings" in result.output
+    assert "warn one" in result.output

--- a/tests/unit/test_db_export.py
+++ b/tests/unit/test_db_export.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from noteshift.db_export import export_child_database
+
+
+def test_export_child_database_success(tmp_path: Path) -> None:
+    client = MagicMock()
+    client.get_data_source.return_value = {
+        "properties": {"Name": {"type": "title"}},
+    }
+    client.query_data_source.return_value = [{"id": "r1"}, {"id": "r2"}]
+
+    result = export_child_database(
+        client=client,
+        data_source_id="db-1",
+        title="Team Tasks",
+        out_dir=tmp_path,
+    )
+
+    assert result.data_sources_exported == 1
+    assert result.rows_exported == 2
+    assert result.files_written == 3
+    assert result.warnings == []
+
+
+def test_export_child_database_handles_schema_error(tmp_path: Path) -> None:
+    client = MagicMock()
+    client.get_data_source.side_effect = RuntimeError("schema boom")
+    client.query_data_source.return_value = [{"id": "r1"}]
+
+    result = export_child_database(
+        client=client,
+        data_source_id="db-1",
+        title="Team Tasks",
+        out_dir=tmp_path,
+    )
+
+    assert result.rows_exported == 1
+    assert result.files_written == 2
+    assert any("Failed to fetch schema" in warning for warning in result.warnings)
+
+
+def test_export_child_database_handles_query_error(tmp_path: Path) -> None:
+    client = MagicMock()
+    client.get_data_source.return_value = {"properties": {}}
+    client.query_data_source.side_effect = RuntimeError("query boom")
+
+    result = export_child_database(
+        client=client,
+        data_source_id="db-1",
+        title="Team Tasks",
+        out_dir=tmp_path,
+    )
+
+    assert result.rows_exported == 0
+    assert result.files_written == 2
+    assert any("Failed to query data source" in warning for warning in result.warnings)

--- a/tests/unit/test_notion.py
+++ b/tests/unit/test_notion.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from noteshift.notion import NotionClient
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.content = b"file-bytes"
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, _url: str, params=None):
+        _ = params
+        return self._responses.pop(0)
+
+    def post(self, _url: str, json=None):
+        _ = json
+        return self._responses.pop(0)
+
+
+def test_list_block_children_handles_pagination(monkeypatch) -> None:
+    responses = [
+        _FakeResponse(
+            {"results": [{"id": "a"}], "has_more": True, "next_cursor": "c1"}
+        ),
+        _FakeResponse(
+            {"results": [{"id": "b"}], "has_more": False, "next_cursor": None}
+        ),
+    ]
+
+    monkeypatch.setattr(
+        "noteshift.notion.httpx.Client", lambda **_kwargs: _FakeClient(responses)
+    )
+
+    client = NotionClient(token="secret")
+    blocks = client.list_block_children("block-1")
+
+    assert [block["id"] for block in blocks] == ["a", "b"]
+
+
+def test_query_data_source_handles_pagination(monkeypatch) -> None:
+    responses = [
+        _FakeResponse(
+            {"results": [{"id": "r1"}], "has_more": True, "next_cursor": "c1"}
+        ),
+        _FakeResponse(
+            {"results": [{"id": "r2"}], "has_more": False, "next_cursor": None}
+        ),
+    ]
+
+    monkeypatch.setattr(
+        "noteshift.notion.httpx.Client", lambda **_kwargs: _FakeClient(responses)
+    )
+
+    client = NotionClient(token="secret")
+    rows = client.query_data_source("db-1")
+
+    assert [row["id"] for row in rows] == ["r1", "r2"]
+
+
+def test_download_file_writes_content(monkeypatch, tmp_path: Path) -> None:
+    responses = [_FakeResponse({})]
+    monkeypatch.setattr(
+        "noteshift.notion.httpx.Client", lambda **_kwargs: _FakeClient(responses)
+    )
+
+    client = NotionClient(token="secret")
+    dest = tmp_path / "asset.bin"
+    client.download_file("https://example.com/file.bin", dest)
+
+    assert dest.exists()
+    assert dest.read_bytes() == b"file-bytes"


### PR DESCRIPTION
Continues readiness execution for:\n- #8 CI quality gate hardening\n- #11 integration confidence via stronger unit coverage baseline\n\nChanges:\n- raises CI coverage gate from 58% to 65%\n- rewrites CLI tests to deterministic mocked command-flow tests\n- adds dedicated unit tests for db export success/error paths\n- adds unit tests for Notion client pagination and file download behavior\n\nOutcome:\n- total coverage now ~76% locally (well above gate)\n- ruff, mypy, pytest, and contract tests all pass