### PR TITLE
Release workflow finalization: SemVer policy + automated tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,66 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
+
+permissions:
+  contents: write
 
 jobs:
-  build:
+  build-and-release:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
 
-    - name: Build package
-      run: uv build
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-    # Optional: Publish to PyPI
-    # - name: Publish to PyPI
-    #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    #   env:
-    #     UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-    #   run: uv publish
+      - name: Install dependencies
+        run: uv sync --extra dev --extra test
+
+      - name: Quality gate
+        run: |
+          uv run ruff format --check .
+          uv run ruff check .
+          uv run mypy src
+          uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=65 tests
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.ref_name }}
+          path: dist/*
+
+      - name: Generate release notes body
+        run: |
+          cat > release_notes.md <<'NOTES'
+          ## Release checklist
+          - Built from tag `${{ github.ref_name }}`
+          - Quality gates passed in CI
+          - Artifacts attached from `dist/`
+
+          See `CHANGELOG.md` for curated changes.
+          NOTES
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body_path: release_notes.md
+          files: |
+            dist/*
+
+      - name: Publish to PyPI (optional)
+        if: ${{ secrets.PYPI_TOKEN != '' }}
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ The format is based on Keep a Changelog, and this project aims to follow Semanti
 - OSS baseline docs (`LICENSE`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`)
 - Initial pytest-vcr contract harness scaffolding
 - Customer pain map and release checklist docs
+- Versioning policy documentation (`docs/spec/versioning_policy.md`)
 
 ### Changed
 - Refreshed README to reflect current CLI behavior and env vars
-- Hardened CI to include formatting and mypy checks
+- Hardened CI to include formatting, blocking mypy, and stronger coverage gate
+- Expanded deterministic contract and integration smoke validation
+- Release workflow now builds artifacts, creates GitHub releases, and optionally publishes to PyPI

--- a/docs/spec/versioning_policy.md
+++ b/docs/spec/versioning_policy.md
@@ -1,0 +1,34 @@
+# Versioning and Release Policy
+
+## Versioning model
+`noteshift` follows Semantic Versioning.
+
+- `MAJOR`: breaking CLI/API behavior changes
+- `MINOR`: backward-compatible features
+- `PATCH`: backward-compatible fixes/docs/internal improvements
+
+## Tagging
+Releases are triggered by pushing tags matching `v*`.
+
+Examples:
+- `v0.2.0`
+- `v0.2.1`
+
+## Release requirements
+Before creating a tag:
+
+1. update `CHANGELOG.md` from `[Unreleased]` into a version section
+2. ensure CI is green on `main`
+3. run local verification:
+   - `uv run ruff format --check .`
+   - `uv run ruff check .`
+   - `uv run mypy src`
+   - `uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=65 tests`
+
+## Automation
+The release workflow performs:
+- full quality gate checks
+- package build via `uv build`
+- artifact upload
+- GitHub release creation with generated notes
+- optional PyPI publish when `PYPI_TOKEN` is configured


### PR DESCRIPTION
Completes #12 by formalizing release/versioning workflow.

Includes:
- release workflow now enforces quality gates, builds artifacts, uploads artifacts, and creates GitHub Releases for tags matching v*
- optional PyPI publish step when PYPI_TOKEN is configured
- added docs/spec/versioning_policy.md with SemVer and tagging policy
- updated CHANGELOG.md with release automation and hardening notes

Validation:
- ruff check
- mypy src
- pytest with coverage gate (65%)
- contract tests (pytest -m contract)
