### PR TITLE
Docs: add minimal user docs set (closes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,25 @@ Teams migrating from Notion to Obsidian consistently report four pains:
 - Resume interrupted runs via checkpoint file
 - Emit migration report (`migration_report.json` + `.md`)
 
+## Documentation
+
+- Docs index: [`docs/`](docs/index.md)
+- Start here: [Getting started](docs/getting-started.md)
+
 ## Installation
+
+### Install from PyPI
+
+```bash
+uv tool install noteshift
+# or
+pipx install noteshift
+```
+
+### Install from source (development)
 
 ```bash
 uv tool install .
-# or for development
 uv sync --extra dev --extra test
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,54 @@
+# CLI reference
+
+## Command overview
+
+- `noteshift export`: export one or more page trees and/or databases
+
+Run:
+
+```bash
+noteshift --help
+noteshift export --help
+```
+
+## Exporting pages
+
+```bash
+noteshift export \
+  --page-id "<page-id>" \
+  --out ./export \
+  --max-depth 2 \
+  --overwrite
+```
+
+## Exporting databases
+
+```bash
+noteshift export \
+  --database-id "<database-id>" \
+  --out ./export \
+  --overwrite
+```
+
+## Exporting multiple sources in one run
+
+You can repeat `--page-id` and `--database-id`.
+
+```bash
+noteshift export \
+  --page-id "<page-id-1>" \
+  --page-id "<page-id-2>" \
+  --database-id "<db-id-1>" \
+  --out ./export \
+  --overwrite
+```
+
+## Common flags (high level)
+
+- `--out`: output directory
+- `--overwrite`: allow writing into a non-empty output directory
+- `--max-depth`: max depth when exporting a page tree
+
+See also:
+- [Concepts](concepts.md)
+- [Filenames + link rewriting](filenames-and-links.md)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,34 @@
+# Concepts
+
+## What noteshift exports
+
+noteshift exports Notion content to Obsidian-friendly Markdown.
+
+Two primary export sources:
+
+- **Page tree**: a root page and its child pages (up to `max_depth`)
+- **Database**: a Notion database / data source exported via the Notion API layer
+
+## Checkpoint / resume
+
+Exports can be long-running. noteshift writes a `.checkpoint.json` file in the output directory.
+
+- If an export is interrupted, running the same export again will resume using the checkpoint.
+- Use `--force` (or `force=True` in the library config) to start fresh.
+
+## Output layout
+
+The output directory contains:
+
+- Markdown files (pages)
+- A folder tree reflecting the exported structure
+- Downloaded assets (attachments)
+- Migration report files (`migration_report.json` and `migration_report.md`)
+
+## Library API
+
+If you are integrating noteshift into another tool (e.g., a GUI), use the library API:
+
+- `noteshift.types.ExportPlan`
+- `noteshift.types.NoteshiftConfig`
+- `noteshift.api.run_export(plan, config, progress=...)`

--- a/docs/filenames-and-links.md
+++ b/docs/filenames-and-links.md
@@ -1,0 +1,22 @@
+# Filenames + link rewriting
+
+## Goals
+
+- **Predictable filenames** so exported notes are stable across runs
+- **Obsidian-compatible internal links** so navigation works after migration
+
+## Filenames
+
+noteshift slugifies titles and ensures uniqueness.
+
+If you see collisions (two pages with the same title), noteshift will disambiguate filenames.
+
+## Link rewriting
+
+Notion internal links are rewritten to point at the exported Markdown notes.
+
+If you find a link that did not rewrite correctly:
+
+1. Check the migration report warnings
+2. Confirm both source pages were included in your export scope
+3. Re-run the export (resume will be fast) after adjusting scope

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,51 @@
+# Getting started
+
+## 1) Create a Notion integration token
+
+Create a Notion integration and copy its token.
+
+Set it in your environment:
+
+```bash
+export NOTION_TOKEN="secret_xxx"
+```
+
+## 2) Install noteshift
+
+### Using uv (recommended)
+
+```bash
+uv tool install noteshift
+```
+
+### Using pipx
+
+```bash
+pipx install noteshift
+```
+
+> If you are developing locally, see the project README for `uv sync` and dev extras.
+
+## 3) Run your first export (page tree)
+
+```bash
+noteshift export \
+  --page-id "<notion-page-id>" \
+  --out ./export \
+  --max-depth 2 \
+  --overwrite
+```
+
+## 4) What you get
+
+A successful run writes:
+
+- Markdown files for exported pages
+- Downloaded assets inside the export tree
+- `.checkpoint.json` (resume support)
+- `migration_report.json`
+- `migration_report.md`
+
+Next:
+- Learn the available flags in the [CLI reference](cli.md)
+- Understand checkpoints and export scope in [Concepts](concepts.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# noteshift docs
+
+- [Getting started](getting-started.md)
+- [CLI reference](cli.md)
+- [Concepts](concepts.md)
+- [Filenames + link rewriting](filenames-and-links.md)
+- [Migration report](migration-report.md)
+- [Troubleshooting](troubleshooting.md)
+
+> These docs describe the open-source CLI and the public Python library API.

--- a/docs/migration-report.md
+++ b/docs/migration-report.md
@@ -1,0 +1,24 @@
+# Migration report
+
+Every successful run writes two report files:
+
+- `migration_report.json`
+- `migration_report.md`
+
+## What it contains
+
+The report summarizes counts such as:
+
+- pages exported
+- databases exported
+- rows exported
+- attachments downloaded
+- files written
+- warnings
+
+## How to use it
+
+- Treat warnings as a checklist for manual validation.
+- Use the counts to confirm export completeness across re-runs.
+
+If you need to restart a migration from scratch, use `--force` to discard the checkpoint.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting
+
+## Missing token / auth errors
+
+Set `NOTION_TOKEN`:
+
+```bash
+export NOTION_TOKEN="secret_xxx"
+```
+
+## Output directory is not empty
+
+Use `--overwrite` or choose a new output directory.
+
+## Export is interrupted
+
+Re-run the same command: noteshift will resume using `.checkpoint.json`.
+
+To start fresh, use `--force`.
+
+## Rate limits / transient API failures
+
+- Re-run (resume should skip already-exported items).
+- Consider exporting fewer sources at once.
+
+## Links not rewriting as expected
+
+- Confirm both pages are in the export scope.
+- Check warnings in `migration_report.md`.


### PR DESCRIPTION
Closes #17.

Adds a minimal user-facing documentation set under `docs/` and links it from the README:
- Getting started
- CLI reference
- Concepts
- Filenames + link rewriting
- Migration report
- Troubleshooting

These are intentionally lightweight Markdown pages to unblock OSS users now; we can evolve into a docs site later (MkDocs/GitHub Pages) if desired.