### PR TITLE
API: document + test ProgressEvent contract (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Teams migrating from Notion to Obsidian consistently report four pains:
 
 - Docs index: [`docs/`](docs/index.md)
 - Start here: [Getting started](docs/getting-started.md)
+- Library integration: [API contract](docs/api-contract.md)
 
 ## Installation
 

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,57 @@
+# API contract (library)
+
+This page documents the public Python API intended for consumers such as `noteshift-gui`.
+
+## Stable entry point
+
+- `noteshift.api.run_export(plan, config, progress=None) -> noteshift.types.ExportResult`
+
+### Inputs
+
+- `noteshift.types.ExportPlan`
+  - `page_ids: list[str]` — zero or more root page IDs
+  - `database_ids: list[str]` — zero or more database/data source IDs
+- `noteshift.types.NoteshiftConfig`
+  - `notion_token: str`
+  - `out_dir: Path`
+  - `overwrite: bool`
+  - `force: bool`
+  - `max_depth: int`
+  - `fail_fast: bool`
+
+### Output
+
+- `noteshift.types.ExportResult` — summary counts, paths, warnings, errors.
+
+## Progress events
+
+`run_export()` may emit `noteshift.events.ProgressEvent` objects to the provided `progress` callback.
+
+### Event types (stable)
+
+`ProgressEvent.type` is one of:
+
+- `phase` — major phase transitions (e.g. starting)
+- `item_start` — export of a single item is starting
+- `item_done` — export of a single item completed successfully
+- `warning` — non-fatal warning (should be shown to user)
+- `error` — item-level failure (may be non-fatal unless `fail_fast=True`)
+- `checkpoint` — checkpoint file saved
+- `summary` — final summary message
+
+### Field expectations
+
+- `item_start`, `item_done`, `warning`, `error`:
+  - `id` is set to the item ID
+  - `title` is set to `page` or `database`
+- `phase`, `checkpoint`, `summary`:
+  - `message` is set
+
+### Ordering invariants (best-effort)
+
+- A run emits a `phase` event with `message="starting_export"` before any `item_start` events.
+- For each item that completes successfully, `item_start` is followed by `item_done` with the same `id`.
+- For each item that fails, an `error` event is emitted with the same `id`.
+- A `summary` event is emitted at the end of a run.
+
+> Note: The library is free to add new event types in a future major version.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,5 +6,6 @@
 - [Filenames + link rewriting](filenames-and-links.md)
 - [Migration report](migration-report.md)
 - [Troubleshooting](troubleshooting.md)
+- [API contract](api-contract.md)
 
 > These docs describe the open-source CLI and the public Python library API.

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -30,7 +30,7 @@ def test_run_export_validation_errors(tmp_path: Path) -> None:
 def test_run_export_emits_progress_events(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    events: list[str] = []
+    events: list[tuple[str, str | None]] = []
 
     def fake_export_page_tree(**_kwargs):
         checkpoint = _kwargs["checkpoint"]
@@ -47,11 +47,17 @@ def test_run_export_emits_progress_events(
     )
     plan = ExportPlan(page_ids=["root-page-id"], database_ids=[])
 
-    result = run_export(plan, config, progress=lambda e: events.append(e.type))
+    result = run_export(plan, config, progress=lambda e: events.append((e.type, e.id)))
 
     assert result.pages_exported == 1
-    assert "phase" in events
-    assert "item_start" in events
-    assert "item_done" in events
-    assert "checkpoint" in events
-    assert "summary" in events
+
+    # Ordering invariants
+    assert events[0][0] == "phase"
+    assert ("item_start", "root-page-id") in events
+    assert ("item_done", "root-page-id") in events
+    assert any(t == "checkpoint" for t, _ in events)
+    assert events[-1][0] == "summary"
+
+    start_idx = events.index(("item_start", "root-page-id"))
+    done_idx = events.index(("item_done", "root-page-id"))
+    assert start_idx < done_idx


### PR DESCRIPTION
Closes #20.

- Adds `docs/api-contract.md` documenting the stable library entrypoint (`run_export`) and ProgressEvent semantics for consumers (e.g. noteshift-gui).
- Links the new doc from `docs/index.md` and the README.
- Tightens unit test to assert basic ordering invariants for progress events (phase first, summary last, item_start before item_done for a successful item).