### PR TITLE
CI/Release: enable PyPI trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build-and-release:
@@ -61,8 +62,5 @@ jobs:
           files: |
             dist/*
 
-      - name: Publish to PyPI (optional)
-        if: ${{ secrets.PYPI_TOKEN != '' }}
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish
+      - name: Publish to PyPI (trusted publishing)
+        run: uv publish --trusted-publishing=always


### PR DESCRIPTION
Enables PyPI Trusted Publishing for releases by:
- adding `permissions: id-token: write`
- switching `uv publish` to `--trusted-publishing=always` (no PYPI_TOKEN secret required)

Follow-up: configure the Trusted Publisher in PyPI for project `noteshift` to allow this workflow/repo.