### PR TITLE
Branding: use NoteShift as display name (keep package/CLI as noteshift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# noteshift
+# NoteShift (`noteshift`)
 
-`noteshift` exports Notion content to Obsidian-friendly Markdown with predictable filenames, link rewriting, and checkpoint/resume support.
+**NoteShift** exports Notion content to Obsidian-friendly Markdown with predictable filenames, link rewriting, and checkpoint/resume support.
 
 [![CI](https://github.com/Fragment256/noteshift/actions/workflows/ci.yml/badge.svg)](https://github.com/Fragment256/noteshift/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/noteshift.svg)](https://pypi.org/project/noteshift/)
@@ -16,7 +16,7 @@ Teams migrating from Notion to Obsidian consistently report four pains:
 3. long exports failing midway without resume
 4. low confidence in migration correctness
 
-`noteshift` is focused on solving those pains first.
+NoteShift is focused on solving those pains first.
 
 ## Current capabilities
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,8 +1,8 @@
 # Concepts
 
-## What noteshift exports
+## What NoteShift exports
 
-noteshift exports Notion content to Obsidian-friendly Markdown.
+NoteShift exports Notion content to Obsidian-friendly Markdown.
 
 Two primary export sources:
 
@@ -11,7 +11,7 @@ Two primary export sources:
 
 ## Checkpoint / resume
 
-Exports can be long-running. noteshift writes a `.checkpoint.json` file in the output directory.
+Exports can be long-running. NoteShift writes a `.checkpoint.json` file in the output directory.
 
 - If an export is interrupted, running the same export again will resume using the checkpoint.
 - Use `--force` (or `force=True` in the library config) to start fresh.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ Set it in your environment:
 export NOTION_TOKEN="secret_xxx"
 ```
 
-## 2) Install noteshift
+## 2) Install NoteShift
 
 ### Using uv (recommended)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# noteshift docs
+# NoteShift docs
 
 - [Getting started](getting-started.md)
 - [CLI reference](cli.md)


### PR DESCRIPTION
Closes #32.

- Presents "NoteShift" as the human-facing name in README/docs.
- Keeps technical identifiers unchanged: PyPI/project slug, Python import, and CLI command remain `noteshift`.

This avoids breaking installs while giving us a consistent brand.