### PR TITLE
README: remove roadmap/readiness section (closes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,6 @@ To re-record cassettes intentionally, set a real token in your environment and r
 VCR_RECORD_MODE=once uv run pytest -m contract
 ```
 
-## Roadmap and readiness
-
-Readiness work is tracked in GitHub issues:
-
-- Epic: transfer + production/open-source readiness
-- OSS baseline docs and metadata
-- CI hardening
-- customer-pain validation matrix
-- contract/e2e test expansion
-
 ## License
 
 MIT


### PR DESCRIPTION
Closes #34.

Removes the "Roadmap and readiness" section from the README to keep it focused on what NoteShift is and how to use it. Roadmap/work tracking remains in GitHub issues.