### PR TITLE
ci: add required check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,41 @@ on:
     branches: [main]
 
 jobs:
+  required:
+    name: required
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra test
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Ruff lint
+        run: uv run ruff check .
+
+      - name: Type check
+        run: uv run mypy src
+
+      - name: Unit and integration tests
+        run: uv run pytest --cov=noteshift --cov-report=term --cov-fail-under=65 tests/
+
+      - name: Build package
+        run: uv build
+
   quality:
+    name: matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Adds a single stable CI job named "required" intended to be configured as a required status check in branch protection.

Closes #42
