### PR TITLE
CI/Test: exclude contract tests from default run (closes #46)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ ignore = ["B008"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
-addopts = "-q"
+addopts = "-q -m 'not contract'"
 testpaths = ["tests"]
 markers = [
     "contract: deterministic API contract tests (vcr-backed)",


### PR DESCRIPTION
Closes #46

- Exclude contract tests from the default pytest run (they are still runnable explicitly via `-m contract`).

Checks:
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/`
