### PR TITLE
ci(release): fix PyPI publish action ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
             dist/*
 
       - name: Publish to PyPI (trusted publishing)
-        uses: pypa/gh-action-pypi-publish@releases/v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # No API token is required for trusted publishing.
           # The action will use the GitHub OIDC token.


### PR DESCRIPTION
Fix Release workflow: correct PyPI publish action ref (`@release/v1`).
