### PR TITLE
Release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.3] - 2026-03-11
+- Fix: resolve Notion inline database IDs (database_id → data_source_id) so DB rows export correctly on Notion API 2025-09-03+.
+- Fix: render bookmark blocks as Markdown links.
+- Tests: add unit coverage for resolution paths and bookmark rendering.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project aims to follow Semantic Versioning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noteshift"
-version = "0.1.2"
+version = "0.1.3"
 description = "Export Notion pages and databases to Obsidian-friendly Markdown."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ wheels = [
 
 [[package]]
 name = "noteshift"
-version = "0.1.0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What
Release bump to **0.1.3**.

## Changes
- Fix: resolve Notion inline database IDs (database_id → data_source_id) so DB rows export correctly on Notion API 2025-09-03+.
- Fix: render bookmark blocks as Markdown links.
- Tests: add unit coverage for resolution paths and bookmark rendering.

## Checklist
- [x] ruff format/check
- [x] mypy
- [x] pytest

Closes #59 (release), and is a prerequisite for #60 (PyPI clean install verification).
